### PR TITLE
Opnsense correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,22 @@ To use this image you need an existing DHCP server where you can set this TFTP s
 
 ### Router Setup Examples
 
-#### PFSense/OPNsense
+#### PFSense
 Services -> DHCP Server
 
 Set both the option for "TFTP Server" and the options under the Advanced "Network Booting" section. 
 * check enable
 * Next server- IP used for TFTP Server
+* Default BIOS file name- `netboot.xyz.kpxe`
+* UEFI 32 bit file name- `netboot.xyz.efi`
+* UEFI 64 bit file name- `netboot.xyz.efi`
+
+#### OPNsense
+Services -> DHCP Server
+
+Under the Advanced "Network Booting" section. 
+* check enable
+* Next server- IP of docker host
 * Default BIOS file name- `netboot.xyz.kpxe`
 * UEFI 32 bit file name- `netboot.xyz.efi`
 * UEFI 64 bit file name- `netboot.xyz.efi`

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,12 +29,22 @@ app_setup_block: |
   
   ### Router Setup Examples
 
-  #### PFSense/OPNsense
+  #### PFSense
   Services -> DHCP Server
 
   Set both the option for "TFTP Server" and the options under the Advanced "Network Booting" section. 
   * check enable
   * Next server- IP used for TFTP Server
+  * Default BIOS file name- `netboot.xyz.kpxe`
+  * UEFI 32 bit file name- `netboot.xyz.efi`
+  * UEFI 64 bit file name- `netboot.xyz.efi`
+
+  #### OPNsense
+  Services -> DHCP Server
+
+  Under the Advanced "Network Booting" section. 
+  * check enable
+  * Next server- IP of docker host
   * Default BIOS file name- `netboot.xyz.kpxe`
   * UEFI 32 bit file name- `netboot.xyz.efi`
   * UEFI 64 bit file name- `netboot.xyz.efi`


### PR DESCRIPTION
Had to remove the TFTP bit in opnsense to get EFI booting.

Have tested, can boot BIOS and EFI booting with this setup on OPNSense.  Appears that the TFTP setup isn't required for OPNSense and if it is entered, it breaks EFI boot.