### PR TITLE
Add env var for custom tftp port range

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -35,6 +35,7 @@ param_usage_include_env: false
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "MENU_VERSION", env_value: "1.9.9", desc: "Specify a specific version of boot files you want to use from NETBOOT.XYZ (unset pulls latest)"}
+  - { env_var: "PORT_RANGE", env_value: "30000:30010", desc: "Specify the port range tftp will use for data transfers [(see Wikipedia)](https://en.wikipedia.org/wiki/Trivial_File_Transfer_Protocol#Details)"}
 opt_param_usage_include_ports: true
 opt_param_ports:
   - { external_port: "8080", internal_port: "80", port_desc: "NGINX server for hosting assets." }

--- a/root/etc/services.d/tftp/run
+++ b/root/etc/services.d/tftp/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 /usr/sbin/in.tftpd \
-	--foreground --listen --user abc --secure /config/menus
+	--foreground --listen --user abc --secure "${PORT_RANGE:+--port-range $PORT_RANGE}" /config/menus

--- a/root/etc/services.d/tftp/run
+++ b/root/etc/services.d/tftp/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 /usr/sbin/in.tftpd \
-	--foreground --listen --user abc --secure "${PORT_RANGE:+--port-range $PORT_RANGE}" /config/menus
+	--foreground --listen --user abc --secure ${PORT_RANGE:+--port-range $PORT_RANGE} /config/menus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ X] I have read the [contributing](https://github.com/linuxserver/docker-netbootxyz/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Add `PORT_RANGE` env var that sets the `--port-range` option for tftp.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
tftp uses an ephemeral port range for data transfers. If you have a firewall, you need to be able to specify the range so you can add an allow rule.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested transfers both with the env var and without.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
