### PR TITLE
rebase to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:3.19
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.19
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -145,7 +145,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - {date: "17.11.23:", desc: "Rebase to Alpine 3.19."}
+  - {date: "08.12.23:", desc: "Rebase to Alpine 3.19."}
   - {date: "17.11.23:", desc: "Rebase to Alpine 3.18."}
   - {date: "01.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "05.03.23:", desc: "Rebase to Alpine 3.17."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -145,6 +145,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - {date: "17.11.23:", desc: "Rebase to Alpine 3.19."}
   - {date: "17.11.23:", desc: "Rebase to Alpine 3.18."}
   - {date: "01.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "05.03.23:", desc: "Rebase to Alpine 3.17."}


### PR DESCRIPTION
 - [X] I have read the [contributing](https://github.com/linuxserver/docker-netbootxyz/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Rebase to 3.19

## Benefits of this PR and context:
why not

## How Has This Been Tested?
tested on 
```
Distributor ID: Debian
Description:    Debian GNU/Linux 12 (bookworm)
Release:        12
Codename:       bookworm
```
kernel: 6.1.0-10-amd64 x86_64
Docker version 24.0.7, build afdd53b
Docker Compose version v2.21.0

Successfully booted windows via PE and debian live without issues.
upgraded from current latest to this PR.

