### PR TITLE
rebase tftp branch to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:3.19
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.19
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -128,6 +128,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - {date: "08.12.23:", desc: "Rebase tftp branch to Alpine 3.19."}
   - {date: "17.11.23:", desc: "Rebase tftp branch to Alpine 3.18."}
   - {date: "01.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "05.03.23:", desc: "Rebase tftp branch to Alpine 3.17."}


### PR DESCRIPTION
 - [X] I have read the [contributing](https://github.com/linuxserver/docker-netbootxyz/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Rebase to 3.19

## Benefits of this PR and context:
why not

## How Has This Been Tested?
I did not test this branch. I tested master in  https://github.com/linuxserver/docker-netbootxyz/pull/59